### PR TITLE
Use upstream vcpkg branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = ../vcpkg.git
-	branch = arm64-osx-mixxx
+	url = https://github.com/mixxxdj/vcpkg.git
+	branch = 2.4
 [submodule "mixxx"]
 	path = mixxx
 	url = https://github.com/mixxxdj/mixxx.git

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In short, this repo builds Mixxx's dependencies, including a patched version of 
 
 ## Upstreaming process
 
-While the `main` branch of Mixxx can already be compiled for arm64 macOS using the right flags ([see the CI workflow](https://github.com/fwcd/m1xxx/blob/3595ff0f1da65a9ad7504a70f2d693d55dcf2b19/.github/workflows/build.yml#L94-L108)), [the patches to the dependencies in `vcpkg`](https://github.com/fwcd/vcpkg/compare/mixxxdj:2.4...fwcd:arm64-osx-mixxx) have not been (completely) upstreamed yet.
+Both the `main` and the `vcpkg` branch now use the official upstream revisions.
 
 ## Building natively on Apple Silicon (arm64 macOS) hosts
 

--- a/scripts/install-vcpkg-deps
+++ b/scripts/install-vcpkg-deps
@@ -67,9 +67,7 @@ PLATFORM_PACKAGES = {
 }
 
 # Packages to be built for the host architecture when crosscompiling
-HOST_PACKAGES = [
-    'qt5-host-tools',
-]
+HOST_PACKAGES = []
 
 def platform_triplet():
     arch = TRIPLET_ARCHS.get(platform.machine(), None)


### PR DESCRIPTION
This means we finally don't have to vendor any branches anymore.