### PR TITLE
Set `CMAKE_OSX_ARCHITECTURES` instead of explicit flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,7 @@ jobs:
         -DCMAKE_C_COMPILER=$(xcrun -find cc)
         -DCMAKE_CXX_COMPILER=$(xcrun -find c++)
         -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0"
-        -DCMAKE_C_FLAGS="-arch arm64 -mmacosx-version-min=11.0"
-        -DCMAKE_CXX_FLAGS="-arch arm64 -mmacosx-version-min=11.0"
+        -DCMAKE_OSX_ARCHITECTURES=arm64
       working-directory: mixxx
     - name: Upload Mixxx configuration logs
       if: always()


### PR DESCRIPTION
This should hopefully eliminate the need for custom compiler flags.