### PR TITLE
Build on macOS 13 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,13 @@ jobs:
         # TODO: Share the key with the setup step
         path: ${{ matrix.ccache_path }}
         key: ccache-${{ matrix.triplet }}-${{ env.mixxx_commit }}-${{ github.ref }}-${{ github.run_number }}
+    - name: Work around race condition in CPack
+      if: runner.os == 'macOS'
+      run: |
+        # TODO: Replace this with a better solution
+        # See https://github.com/actions/runner-images/issues/7522
+        echo Killing XProtect...; sudo pkill -9 XProtect >/dev/null || true;
+        echo Waiting for XProtect process...; while pgrep XProtect; do sleep 3; done;
     - name: Package Mixxx
       if: matrix.package_extension && matrix.cpack_generator
       run: cpack -G ${{ matrix.cpack_generator }} -V && mv *.${{ matrix.package_extension }} "mixxx-${{ env.mixxx_version }}-${{ matrix.triplet }}${{ matrix.suffix }}.${{ matrix.package_extension }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
         - name: macOS (arm64)
-          os: macos-11
+          os: macos-13
           suffix: ''
           triplet: arm64-osx-min1100-release
           host_triplet: x64-osx-min1100-release
@@ -31,7 +31,7 @@ jobs:
           cmake_args: >-
             -DMACOS_BUNDLE=ON
         - name: macOS (x86_64)
-          os: macos-11
+          os: macos-13
           suffix: ''
           triplet: x64-osx-min1100-release
           host_triplet: x64-osx-min1100-release
@@ -41,7 +41,7 @@ jobs:
           cmake_args: >-
             -DMACOS_BUNDLE=ON
         - name: macOS (arm64, Debug Assertions)
-          os: macos-11
+          os: macos-13
           suffix: '-debugasserts'
           triplet: arm64-osx-min1100-release
           host_triplet: x64-osx-min1100-release
@@ -52,7 +52,7 @@ jobs:
             -DDEBUG_ASSERTIONS_FATAL=ON
             -DMACOS_BUNDLE=ON
         - name: macOS (x86_64, Debug Assertions)
-          os: macos-11
+          os: macos-13
           suffix: '-debugasserts'
           triplet: x64-osx-min1100-release
           host_triplet: x64-osx-min1100-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,24 @@ jobs:
       run: |
         ${{ env.SCRIPTS_ROOT }}/install-macos-deps
         xcrun --show-sdk-version
+    # TODO: Replace this with a better solution
+    # See https://github.com/actions/runner-images/issues/7522
+    - name: Disable XProtect to work around race condition in CPack
+      if: runner.os == 'macOS'
+      run: |
+        set +e
+        set -x
+        daemons=(
+          com.apple.XProtect.daemon.scan
+          com.apple.XprotectFramework.PluginService
+          com.apple.XprotectFramework.scan
+          com.apple.metadata.mds
+          com.apple.metadata.mds.index
+        )
+        for daemon in "${daemons[@]}"; do
+          sudo launchctl stop "$daemon"
+          sudo launchctl disable "system/$daemon"
+        done
 
     # TODO: Remove this workaround once CMake in GitHub's runner image is
     # updated to 3.29.2, i.e. the `PACKAGE_PREFIX_DIR` issue is fixed again (the
@@ -212,13 +230,6 @@ jobs:
         # TODO: Share the key with the setup step
         path: ${{ matrix.ccache_path }}
         key: ccache-${{ matrix.triplet }}-${{ env.mixxx_commit }}-${{ github.ref }}-${{ github.run_number }}
-    - name: Work around race condition in CPack
-      if: runner.os == 'macOS'
-      run: |
-        # TODO: Replace this with a better solution
-        # See https://github.com/actions/runner-images/issues/7522
-        echo Killing XProtect...; sudo pkill -9 XProtect >/dev/null || true;
-        echo Waiting for XProtect process...; while pgrep XProtect; do sleep 3; done;
     - name: Package Mixxx
       if: matrix.package_extension && matrix.cpack_generator
       run: cpack -G ${{ matrix.cpack_generator }} -V && mv *.${{ matrix.package_extension }} "mixxx-${{ env.mixxx_version }}-${{ matrix.triplet }}${{ matrix.suffix }}.${{ matrix.package_extension }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,9 @@ jobs:
         )
         for daemon in "${daemons[@]}"; do
           sudo launchctl stop "$daemon"
+          echo "  -> $?"
           sudo launchctl disable "system/$daemon"
+          echo "  -> $?"
         done
 
     # TODO: Remove this workaround once CMake in GitHub's runner image is

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ env:
   VCPKG_ROOT: '${{ github.workspace }}/vcpkg'
   MIXXX_ROOT: '${{ github.workspace }}/mixxx'
   SCRIPTS_ROOT: '${{ github.workspace }}/scripts'
+  XCODE_ROOT: /Applications/Xcode_15.2.app
 
 jobs:
   build:
@@ -100,6 +101,8 @@ jobs:
       with:
         fetch-depth: '0' # to compute the monotonic version correctly
         submodules: true
+    - name: Output runner info
+      run: uname -a
     - name: Fetch versions and paths
       run: |
         for mod in "${{ env.VCPKG_ROOT }}" "${{ env.MIXXX_ROOT }}"; do
@@ -115,6 +118,9 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         ${{ env.SCRIPTS_ROOT }}/install-macos-deps
+        sudo xcode-select -s "${{ env.XCODE_ROOT }}"
+        echo "==> Build environment"
+        xcode-select -p
         xcrun --show-sdk-version
     # TODO: Replace this with a better solution
     # See https://github.com/actions/runner-images/issues/7522

--- a/scripts/install-macos-deps
+++ b/scripts/install-macos-deps
@@ -10,8 +10,10 @@ fi
 echo "==> Installing system dependencies with Homebrew..."
 brew install \
   automake \
+  autoconf \
   autoconf-archive \
   ccache \
+  libtool \
   nasm \
   ninja \
   pkg-config


### PR DESCRIPTION
Given that GitHub has phased out macOS 11 runners, we have to migrate to a newer macOS version.