### PR TITLE
Update the 2.4 vcpkg dependencies

### DIFF
--- a/scripts/install-vcpkg-deps
+++ b/scripts/install-vcpkg-deps
@@ -20,12 +20,15 @@ TRIPLET_ARCHS = {
 }
 
 # Packages to be built for the target architecture
-# Source: https://github.com/daschuer/vcpkg/blob/1023e7bdc915e9b69ce0dbdc2f750921e15d4499/.github/workflows/build.yml
+# Source: https://github.com/mixxxdj/vcpkg/blob/2.4/.github/workflows/build.yml
 TARGET_PACKAGES = [
+    'ableton',
+    'benchmark',
     'chromaprint',
     'fdk-aac',
     'ffmpeg',
     'fftw3',
+    'gtest',
     'hidapi',
     'libdjinterop',
     'libebur128',


### PR DESCRIPTION
Most notably, this includes `gtest` which has recently been devendored from the Mixxx source tree.