### PR TITLE
Build on (arm64) macOS 14 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,30 +22,30 @@ jobs:
       matrix:
         include:
         - name: macOS (arm64)
-          os: macos-13
+          os: macos-14
           suffix: ''
           triplet: arm64-osx-min1100-release
-          host_triplet: x64-osx-min1100-release
+          host_triplet: arm64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg
           cmake_args: >-
             -DMACOS_BUNDLE=ON
         - name: macOS (x86_64)
-          os: macos-13
+          os: macos-14
           suffix: ''
           triplet: x64-osx-min1100-release
-          host_triplet: x64-osx-min1100-release
+          host_triplet: arm64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg
           cmake_args: >-
             -DMACOS_BUNDLE=ON
         - name: macOS (arm64, Debug Assertions)
-          os: macos-13
+          os: macos-14
           suffix: '-debugasserts'
           triplet: arm64-osx-min1100-release
-          host_triplet: x64-osx-min1100-release
+          host_triplet: arm64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg
@@ -53,10 +53,10 @@ jobs:
             -DDEBUG_ASSERTIONS_FATAL=ON
             -DMACOS_BUNDLE=ON
         - name: macOS (x86_64, Debug Assertions)
-          os: macos-13
+          os: macos-14
           suffix: '-debugasserts'
           triplet: x64-osx-min1100-release
-          host_triplet: x64-osx-min1100-release
+          host_triplet: arm64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg


### PR DESCRIPTION
### Fixes #15 

GitHub now offers [free Apple Silicon runners for open-source projects](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source) under the `macos-14` tag, which this PR migrates our workflows to. Note that we will still have to cross-compile, just the other way around (x86_64 Mixxx will be built on arm64).