### PR TITLE
Build with overlays declared in vcpkg manifest

### DIFF
--- a/vars/vcpkg.sh
+++ b/vars/vcpkg.sh
@@ -3,6 +3,3 @@ rootdir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 if [ -z "$VCPKG_ROOT" ]; then
   export VCPKG_ROOT="$rootdir/vcpkg"
 fi
-
-export VCPKG_OVERLAY_TRIPLETS="$VCPKG_ROOT/overlay/triplets"
-export VCPKG_OVERLAY_PORTS="$VCPKG_ROOT/overlay/osx:$VCPKG_ROOT/overlay/ports"


### PR DESCRIPTION
This effectively applies https://github.com/mixxxdj/vcpkg/pull/119. Once the PR and 2.5 have been merged upstream to 2.5-rel, we should switch back to 2.5-rel here.