### PR TITLE
Bump vcpkg to latest 2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           os: macos-11
           suffix: ''
           triplet: arm64-osx-min1100-release
-          host_triplet: x64-osx-min1015-release
+          host_triplet: x64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg
@@ -33,8 +33,8 @@ jobs:
         - name: macOS (x86_64)
           os: macos-11
           suffix: ''
-          triplet: x64-osx-min1015-release
-          host_triplet: x64-osx-min1015-release
+          triplet: x64-osx-min1100-release
+          host_triplet: x64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg
@@ -44,7 +44,7 @@ jobs:
           os: macos-11
           suffix: '-debugasserts'
           triplet: arm64-osx-min1100-release
-          host_triplet: x64-osx-min1015-release
+          host_triplet: x64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg
@@ -54,8 +54,8 @@ jobs:
         - name: macOS (x86_64, Debug Assertions)
           os: macos-11
           suffix: '-debugasserts'
-          triplet: x64-osx-min1015-release
-          host_triplet: x64-osx-min1015-release
+          triplet: x64-osx-min1100-release
+          host_triplet: x64-osx-min1100-release
           ccache_path: ~/Library/Caches/ccache
           cpack_generator: DragNDrop
           package_extension: dmg


### PR DESCRIPTION
This updates the vcpkg branch. Marked as a draft until the corresponding Mixxx patches fixing the static Linux build have been upstreamed:

- https://github.com/mixxxdj/mixxx/pull/13085
- https://github.com/mixxxdj/mixxx/pull/13087